### PR TITLE
bug: use acmez staging version while in development

### DIFF
--- a/server/cronjobs.go
+++ b/server/cronjobs.go
@@ -351,7 +351,7 @@ func (s *Server) HAproxyExposedPortsProcessor() {
 		// add 80 and 443 to ports
 		portsmap[80] = true
 		portsmap[443] = true
-		if s.ENVIRONMENT == "development" {
+		if !s.isProductionEnvironment() {
 			portsmap[5555] = true
 		}
 		// Check if ports are changed

--- a/server/helpers.go
+++ b/server/helpers.go
@@ -55,3 +55,8 @@ func (s ApplicationSource) GetSourceSummary() string {
 	}
 	return "Unknown"
 }
+
+
+func (s *Server) isProductionEnvironment() bool {
+	return strings.Compare(s.ENVIRONMENT, "production") == 0;
+}

--- a/server/server.go
+++ b/server/server.go
@@ -107,7 +107,7 @@ func (server *Server) Init() {
 
 	// Initiating SSL Manager
 	options := SSL.ManagerOptions{
-		IsStaging:                 false,
+		IsStaging:                 !server.isProductionEnvironment(),
 		Email:                     os.Getenv("ACCOUNT_EMAIL_ID"),
 		AccountPrivateKeyFilePath: os.Getenv("ACCOUNT_PRIVATE_KEY_FILE_PATH"),
 	}

--- a/server/worker_func.go
+++ b/server/worker_func.go
@@ -32,7 +32,7 @@ func (s *Server) ProcessGenerateSSLRequestFromQueue(name string) error {
 	domainRecord.SSLStatus = DomainSSLStatusIssued
 	domainRecord.SSLFullChain = cert
 	domainRecord.SSLIssuedAt = time.Now()
-	domainRecord.SSLIssuer = "Let's Encrypt"
+	domainRecord.SSLIssuer = s.SSL_MANAGER.FetchIssuerName()
 	tx3 := s.DB_CLIENT.Save(&domainRecord)
 	if tx3.Error != nil {
 		log.Println("Failed to update domain ssl certificate in database")

--- a/ssl_manager/constructor.go
+++ b/ssl_manager/constructor.go
@@ -34,7 +34,7 @@ func (s *Manager) Init(ctx context.Context, db gorm.DB, options ManagerOptions) 
 			HTTPClient: &http.Client{
 				Transport: &http.Transport{
 					TLSClientConfig: &tls.Config{
-						InsecureSkipVerify: false,
+						InsecureSkipVerify: options.IsStaging,
 					},
 				},
 			},

--- a/ssl_manager/utils.go
+++ b/ssl_manager/utils.go
@@ -53,3 +53,12 @@ func readPrivateKeyFromFile(keyFile string) (*rsa.PrivateKey, error) {
 	}
 	return privateKey, nil
 }
+
+// Fetch SSL Issuer's Name
+func (s Manager) FetchIssuerName() string {
+	if s.options.IsStaging {
+		return "Let's Encrypt (Staging)"
+	} else {
+		return "Let's Encrypt"
+	}
+}


### PR DESCRIPTION
Fixes #27 

#### Describe the changes you have made in this PR -
- Add helpers to verify `Production` environment
- Use `staging` url and disable tls verification in development
- In staging environment, show issuer name as `Let's Encrypt (Staging)` and normally `Let's Encrypt`

### Screenshots of the changes (If any) -


Note: Please check **Allow edits from maintainers.** before creating the PR. 
