### PR TITLE
fix: disable playground on production for graphql

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -13,6 +13,7 @@ var systemConfig *system_config.Config
 var configFilePath = "/etc/swiftwave/config.yml"
 
 func init() {
+	rootCmd.PersistentFlags().Bool("dev", false, "Run in development mode")
 	rootCmd.AddCommand(initCmd)
 	rootCmd.AddCommand(setupCmd)
 	rootCmd.AddCommand(infoCmd)

--- a/cmd/start.go
+++ b/cmd/start.go
@@ -10,6 +10,7 @@ var startCmd = &cobra.Command{
 	Short: "Start swiftwave service",
 	Long:  `Start swiftwave service`,
 	Run: func(cmd *cobra.Command, args []string) {
+		systemConfig.IsDevelopmentMode = isDevelopmentMode(cmd)
 		swiftwave.Start(systemConfig)
 	},
 }

--- a/cmd/utils.go
+++ b/cmd/utils.go
@@ -7,6 +7,7 @@ import (
 	"os/exec"
 
 	"github.com/fatih/color"
+	"github.com/spf13/cobra"
 )
 
 func checkIfCommandExists(command string) bool {
@@ -86,4 +87,9 @@ func printError(message string) {
 
 func printInfo(message string) {
 	color.Blue(InfoSymbol + " " + message)
+}
+
+func isDevelopmentMode(cmd *cobra.Command) bool {
+	dev, _ := cmd.Flags().GetBool("dev")
+	return dev
 }

--- a/main.go
+++ b/main.go
@@ -45,6 +45,8 @@ func main() {
 			color.Blue("Please run 'swiftwave init' to initialize a configuration file.")
 			os.Exit(1)
 		}
+		// Set the development mode to false
+		config.IsDevelopmentMode = false
 	}
 
 	// Start the command line interface

--- a/swiftwave_service/graphql/server.go
+++ b/swiftwave_service/graphql/server.go
@@ -2,6 +2,7 @@ package graphql
 
 import (
 	"github.com/99designs/gqlgen/graphql/handler"
+	"github.com/99designs/gqlgen/graphql/handler/extension"
 	"github.com/99designs/gqlgen/graphql/handler/transport"
 	"github.com/99designs/gqlgen/graphql/playground"
 	"github.com/labstack/echo/v4"
@@ -18,7 +19,10 @@ func (server *Server) Initialize() {
 		),
 	)
 	graphqlHandler.AddTransport(&transport.Websocket{})
-	playgroundHandler := playground.Handler("GraphQL", "/graphql")
+
+	if server.SystemConfig.IsDevelopmentMode {
+		graphqlHandler.Use(extension.Introspection{})
+	}
 
 	server.EchoServer.GET("/graphql", func(c echo.Context) error {
 		graphqlHandler.ServeHTTP(c.Response(), c.Request())
@@ -30,8 +34,12 @@ func (server *Server) Initialize() {
 		return nil
 	})
 
-	server.EchoServer.GET("/playground", func(c echo.Context) error {
-		playgroundHandler.ServeHTTP(c.Response(), c.Request())
-		return nil
-	})
+	if server.SystemConfig.IsDevelopmentMode {
+		// Create GraphQL Playground
+		playgroundHandler := playground.Handler("GraphQL", "/graphql")
+		server.EchoServer.GET("/playground", func(c echo.Context) error {
+			playgroundHandler.ServeHTTP(c.Response(), c.Request())
+			return nil
+		})
+	}
 }

--- a/swiftwave_service/main.go
+++ b/swiftwave_service/main.go
@@ -89,7 +89,7 @@ func StartServer(config *system_config.Config, manager *core.ServiceManager, wor
 	// Start the server
 	address := fmt.Sprintf("%s:%d", config.ServiceConfig.BindAddress, config.ServiceConfig.BindPort)
 	if config.ServiceConfig.UseTLS {
-		println("Starting TLS Server")
+		println("TLS Server Started on " + address)
 		
 		tlsCfg := &tls.Config{
 			Certificates: fetchCertificates(config.ServiceConfig.SSLCertificateDir),

--- a/system_config/types.go
+++ b/system_config/types.go
@@ -2,6 +2,7 @@ package system_config
 
 type Config struct {
 	Version           string            `yaml:"version"`
+	IsDevelopmentMode bool              `yaml:"-"`
 	Mode              Mode              `yaml:"mode"`
 	ServiceConfig     ServiceConfig     `yaml:"service"`
 	HAProxyConfig     HAProxyConfig     `yaml:"haproxy"`


### PR DESCRIPTION
Fixes #136

#### Describe the changes you have made in this PR -
- Added `--dev` flag which can be used to do some o/ps in development mode
- Graphql introspection and playground will be the only available in development mode

Note: Please check **Allow edits from maintainers.** before creating the PR. 
