### PR TITLE
feat: added echo middleware to cache js,css,png files upto 1yr

### DIFF
--- a/swiftwave_service/main.go
+++ b/swiftwave_service/main.go
@@ -89,6 +89,27 @@ func StartServer(config *config.Config, manager *service_manager.ServiceManager,
 	}))
 	echoServer.Use(middleware.CORS())
 
+	// Cache middleware
+	// Cache JS, CSS and PNG files for 1 year, as if static content changes, the uri also changes
+	// So setting cache-control header to max-age to 1 year
+	// + it will also set etag header to the file name
+	echoServer.Use(func(next echo.HandlerFunc) echo.HandlerFunc {
+		return func(c echo.Context) error {
+			if strings.HasSuffix(c.Request().RequestURI, ".js") || strings.HasSuffix(c.Request().RequestURI, ".css") || strings.HasSuffix(c.Request().RequestURI, ".png") {
+				s := strings.Split(c.Request().RequestURI, "/")
+				etag := s[len(s)-1]
+				c.Response().Header().Set("Etag", etag)
+				c.Response().Header().Set("Cache-Control", "max-age=31536000")
+				if match := c.Request().Header.Get("If-None-Match"); match != "" {
+					if strings.Contains(match, etag) {
+						return c.NoContent(http.StatusNotModified)
+					}
+				}
+			}
+			return next(c)
+		}
+	})
+
 	// Internal Service Authentication Middleware
 	// Authorization : analytics_token <analytics_id>:<analytics_token>
 	// Only for /service/analytics endpoints


### PR DESCRIPTION
Cache JS, CSS and PNG files for 1 year, as if static content changes, the uri also changes
So setting cache-control header to max-age to 1 year
_it will also set etag header to the file name_


Related #79