### PR TITLE
fix: Switch postgres image to bitnamilegacy/postgresql:17.6.0

### DIFF
--- a/swiftwave_service/cmd/postgres.go
+++ b/swiftwave_service/cmd/postgres.go
@@ -100,7 +100,7 @@ var postgresStartCmd = &cobra.Command{
 			"-v", "/var/lib/swiftwave/postgres:/bitnami/postgresql:rw",
 			"-p", config.LocalConfig.PostgresqlConfig.Host+":"+strconv.Itoa(config.LocalConfig.PostgresqlConfig.Port)+":5432",
 			"--user", "0:0",
-			"bitnami/postgresql:latest")
+			"bitnamilegacy/postgresql:17.6.0")
 		dockerCmd.Stdout = os.Stdout
 		dockerCmd.Stderr = os.Stderr
 		err = dockerCmd.Run()


### PR DESCRIPTION
https://news.broadcom.com/app-dev/broadcom-introduces-bitnami-secure-images-for-production-ready-containerized-applications
