### PR TITLE
fix(ssh): evict zombie pooled connections instead of hanging on them

### DIFF
--- a/ssh_toolkit/command.go
+++ b/ssh_toolkit/command.go
@@ -55,7 +55,7 @@ func ExecCommandOverSSHWithOptions(cmd string,
 	session.Stdout = stdoutBuf
 	session.Stderr = stderrBuf
 	// run command
-	err = session.Run(cmd)
+	err = runCommandWithTimeout(session, cmd, sshCommandMaxDuration)
 	if err != nil {
 		if isErrorWhenSSHClientNeedToBeRecreated(err) || isErrorWhenSSHClientNeedToBeRecreated(errors.New(stderrBuf.String())) {
 			DeleteSSHClient(host)
@@ -81,6 +81,32 @@ func getSSHSessionWithTimeout(client *ssh.Client, timeout int) (*ssh.Session, er
 	case result := <-resultCh:
 		return result.session, result.err
 	case <-time.After(time.Duration(timeout) * time.Second):
+		// the session may still turn up later, it would leak a channel on the server
+		go func() {
+			if result := <-resultCh; result.session != nil {
+				_ = result.session.Close()
+			}
+		}()
 		return nil, fmt.Errorf("session creation timeout after %d seconds", timeout)
+	}
+}
+
+// runCommandWithTimeout is a safety net, a command that never finishes should not pin a
+// goroutine forever. Detecting a dead connection is the pool keepalive's job.
+func runCommandWithTimeout(session *ssh.Session, cmd string, timeout time.Duration) error {
+	if err := session.Start(cmd); err != nil {
+		return err
+	}
+	done := make(chan error, 1)
+	go func() {
+		done <- session.Wait()
+	}()
+	select {
+	case err := <-done:
+		return err
+	case <-time.After(timeout):
+		_ = session.Signal(ssh.SIGKILL)
+		_ = session.Close()
+		return fmt.Errorf("command timeout after %s", timeout)
 	}
 }

--- a/ssh_toolkit/errors.go
+++ b/ssh_toolkit/errors.go
@@ -1,6 +1,8 @@
 package ssh_toolkit
 
 import (
+	"errors"
+	"io"
 	"strings"
 )
 
@@ -23,9 +25,8 @@ var errorsWhenSSHClientNeedToBeRecreated = []string{
 	"connection closed by remote host",
 	"connect failed",
 	"open failed",
-	"handshake failed",
 	"subsystem request failed",
-	"eof",
+	"unexpected eof",
 	"broken pipe",
 	"closing write end of pipe",
 	"connection reset by peer",
@@ -35,6 +36,9 @@ var errorsWhenSSHClientNeedToBeRecreated = []string{
 func isErrorWhenSSHClientNeedToBeRecreated(err error) bool {
 	if err == nil {
 		return false
+	}
+	if errors.Is(err, io.EOF) {
+		return true
 	}
 	errMsg := strings.ToLower(err.Error())
 	for _, msg := range errorsWhenSSHClientNeedToBeRecreated {

--- a/ssh_toolkit/net_conn.go
+++ b/ssh_toolkit/net_conn.go
@@ -42,6 +42,12 @@ func dialWithTimeout(client *ssh.Client, network, address string, timeout time.D
 	case result := <-resultCh:
 		return result.conn, result.err
 	case <-time.After(timeout):
+		// the connection may still turn up later, nobody would be left to close it
+		go func() {
+			if result := <-resultCh; result.conn != nil {
+				_ = result.conn.Close()
+			}
+		}()
 		return nil, fmt.Errorf("dial timeout after %s", timeout)
 	}
 }

--- a/ssh_toolkit/pool.go
+++ b/ssh_toolkit/pool.go
@@ -1,9 +1,12 @@
 package ssh_toolkit
 
 import (
+	"crypto/sha256"
+	"encoding/hex"
 	"errors"
-	"fmt"
 	"log"
+	"net"
+	"strconv"
 	"sync"
 	"time"
 
@@ -27,94 +30,189 @@ func SetValidator(validator ServerOnlineStatusValidator) {
 }
 
 func getSSHClientWithOptions(host string, port int, user string, privateKey string, validate bool) (*ssh.Client, error) {
+	sshClientPool.mutex.RLock()
+	validator := sshClientPool.validator
+	sshClientPool.mutex.RUnlock()
 	// reject if server is offline
-	if validate && sshClientPool.validator != nil && !(*sshClientPool.validator)(host) {
+	if validate && validator != nil && !(*validator)(host) {
 		return nil, errors.New("server is offline, cannot connect to it")
 	}
-	sshClientPool.mutex.RLock()
-	clientEntry, ok := sshClientPool.clients[host]
-	sshClientPool.mutex.RUnlock()
-	if ok {
-		clientEntry.mutex.RLock()
-		c := clientEntry.client
-		clientEntry.mutex.RUnlock()
-		if c != nil {
-			return c, nil
-		}
+	entry, owned := acquireSSHClientEntry(host, port, user, credentialHash(privateKey))
+	if owned {
+		entry.connect(host, port, user, privateKey)
 	}
-	return newSSHClient(host, port, user, privateKey, sshTCPTimeoutSeconds)
+	// a dial plus a handshake, each capped at the tcp timeout, with a little slack
+	client, err := entry.wait(time.Duration(2*sshTCPTimeoutSeconds+1) * time.Second)
+	if err != nil {
+		deleteSSHClientEntry(host, entry)
+		return nil, err
+	}
+	return client, nil
 }
 
-func newSSHClient(host string, port int, user string, privateKey string, timeoutSeconds int) (*ssh.Client, error) {
-	// take pool read lock
-	sshClientPool.mutex.RLock()
-	// check if another goroutine has created the client in the meantime
-	clientEntry, ok := sshClientPool.clients[host]
-	// unlock read
-	sshClientPool.mutex.RUnlock()
-	if ok {
-		// take mutex read lock on the entry
-		clientEntry.mutex.RLock()
-		c := clientEntry.client
-		// unlock the mutex on the entry
-		clientEntry.mutex.RUnlock()
-		if c != nil {
-			// another goroutine has created the client
-			return c, nil
-		}
-		// created record but not yet created the client due to handshake in progress + race condition
-	}
-	// take pool write lock
+// acquireSSHClientEntry returns the pooled entry for host, creating a fresh one when there
+// is none or when the credentials changed. The bool reports whether the caller owns the
+// handshake for the returned entry.
+func acquireSSHClientEntry(host string, port int, user string, credHash string) (*sshClient, bool) {
+	var stale *sshClient
 	sshClientPool.mutex.Lock()
-	sshClientRecord := &sshClient{
-		client: nil,
-		mutex:  &sync.RWMutex{},
+	if entry, ok := sshClientPool.clients[host]; ok {
+		if entry.port == port && entry.user == user && entry.credHash == credHash {
+			sshClientPool.mutex.Unlock()
+			return entry, false
+		}
+		stale = entry
 	}
-	sshClientPool.clients[host] = sshClientRecord
-	// take the lock on the new entry,
-	// so that no other goroutine can create a client for the same host at the same time
-	sshClientRecord.mutex.Lock()
-	// release the global lock
-	// so that operation for other hosts can continue, as ssh handshake can take time
+	entry := &sshClient{
+		ready:    make(chan struct{}),
+		port:     port,
+		user:     user,
+		credHash: credHash,
+	}
+	sshClientPool.clients[host] = entry
 	sshClientPool.mutex.Unlock()
+	if stale != nil {
+		// closing waits for any in-flight handshake, never do that under the pool lock
+		go stale.close()
+	}
+	return entry, true
+}
+
+// deleteSSHClientEntry drops entry from the pool, leaving any newer entry for host intact.
+func deleteSSHClientEntry(host string, entry *sshClient) {
+	sshClientPool.mutex.Lock()
+	if current, ok := sshClientPool.clients[host]; ok && current == entry {
+		delete(sshClientPool.clients, host)
+	}
+	sshClientPool.mutex.Unlock()
+	go entry.close()
+}
+
+func DeleteSSHClient(host string) {
+	sshClientPool.mutex.Lock()
+	entry, ok := sshClientPool.clients[host]
+	if ok {
+		delete(sshClientPool.clients, host)
+	}
+	sshClientPool.mutex.Unlock()
+	if ok {
+		go entry.close()
+	}
+}
+
+// private functions
+func (s *sshClient) connect(host string, port int, user string, privateKey string) {
+	defer close(s.ready)
 	signer, err := ssh.ParsePrivateKey([]byte(privateKey))
 	if err != nil {
-		sshClientRecord.mutex.Unlock()
-		DeleteSSHClient(host)
-		return nil, err
+		s.err = err
+		return
+	}
+	addr := net.JoinHostPort(host, strconv.Itoa(port))
+	timeout := time.Duration(sshTCPTimeoutSeconds) * time.Second
+	conn, err := net.DialTimeout("tcp", addr, timeout)
+	if err != nil {
+		s.err = err
+		return
+	}
+	// ssh.Dial bounds only the tcp dial, the handshake needs a deadline of its own
+	if err := conn.SetDeadline(time.Now().Add(timeout)); err != nil {
+		_ = conn.Close()
+		s.err = err
+		return
 	}
 	config := &ssh.ClientConfig{
 		User: user,
 		Auth: []ssh.AuthMethod{
 			ssh.PublicKeys(signer),
 		},
-		Timeout:         time.Duration(timeoutSeconds) * time.Second,
+		Timeout:         timeout,
 		HostKeyCallback: ssh.InsecureIgnoreHostKey(),
 	}
-	client, err := ssh.Dial("tcp", fmt.Sprintf("%s:%d", host, port), config)
+	sshConn, chans, reqs, err := ssh.NewClientConn(conn, addr, config)
 	if err != nil {
-		sshClientRecord.mutex.Unlock()
-		DeleteSSHClient(host)
-		return nil, err
+		_ = conn.Close()
+		s.err = err
+		return
 	}
-	sshClientRecord.client = client
-	sshClientRecord.mutex.Unlock()
-	return client, nil
+	if err := conn.SetDeadline(time.Time{}); err != nil {
+		_ = sshConn.Close()
+		s.err = err
+		return
+	}
+	s.client = ssh.NewClient(sshConn, chans, reqs)
+	s.stopKeepAlive = make(chan struct{})
+	go s.keepAlive(host)
 }
 
-func DeleteSSHClient(host string) {
-	sshClientPool.mutex.Lock()
-	clientEntry, ok := sshClientPool.clients[host]
-	if ok {
-		clientEntry.mutex.Lock()
-		if clientEntry.client != nil {
-			err := clientEntry.client.Close()
-			if err != nil {
+func (s *sshClient) wait(timeout time.Duration) (*ssh.Client, error) {
+	select {
+	case <-s.ready:
+		if s.err != nil {
+			return nil, s.err
+		}
+		return s.client, nil
+	case <-time.After(timeout):
+		return nil, errors.New("ssh handshake failed, timed out")
+	}
+}
+
+func (s *sshClient) close() {
+	<-s.ready
+	s.closeOnce.Do(func() {
+		if s.stopKeepAlive != nil {
+			close(s.stopKeepAlive)
+		}
+		if s.client != nil {
+			if err := s.client.Close(); err != nil {
 				log.Println("Error closing ssh client:", err)
 			}
 		}
-		clientEntry.mutex.Unlock()
-		delete(sshClientPool.clients, host)
+	})
+}
+
+// keepAlive evicts a connection that died silently, a firewall dropping an idle flow or a
+// network partition leaves a client that looks healthy but blocks every command forever.
+// Closing it also unblocks whatever is already stuck on it.
+func (s *sshClient) keepAlive(host string) {
+	ticker := time.NewTicker(sshKeepAliveInterval)
+	defer ticker.Stop()
+	failures := 0
+	for {
+		select {
+		case <-s.stopKeepAlive:
+			return
+		case <-ticker.C:
+			if s.ping() {
+				failures = 0
+				continue
+			}
+			failures++
+			if failures >= sshKeepAliveMaxFailures {
+				log.Printf("ssh keepalive failed %d times, dropping connection to %s", failures, host)
+				deleteSSHClientEntry(host, s)
+				return
+			}
+		}
 	}
-	sshClientPool.mutex.Unlock()
+}
+
+func (s *sshClient) ping() bool {
+	// SendRequest itself blocks forever on a dead connection
+	result := make(chan error, 1)
+	go func() {
+		_, _, err := s.client.SendRequest("keepalive@openssh.com", true, nil)
+		result <- err
+	}()
+	select {
+	case err := <-result:
+		return err == nil
+	case <-time.After(sshKeepAliveTimeout):
+		return false
+	}
+}
+
+func credentialHash(privateKey string) string {
+	sum := sha256.Sum256([]byte(privateKey))
+	return hex.EncodeToString(sum[:])
 }

--- a/ssh_toolkit/pool_test.go
+++ b/ssh_toolkit/pool_test.go
@@ -1,0 +1,179 @@
+package ssh_toolkit
+
+import (
+	"crypto/ed25519"
+	"crypto/rand"
+	"encoding/pem"
+	"net"
+	"sync"
+	"testing"
+	"time"
+
+	"golang.org/x/crypto/ssh"
+)
+
+func testPrivateKey(t *testing.T) string {
+	t.Helper()
+	_, key, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	block, err := ssh.MarshalPrivateKey(key, "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	return string(pem.EncodeToMemory(block))
+}
+
+func poolSize() int {
+	sshClientPool.mutex.RLock()
+	defer sshClientPool.mutex.RUnlock()
+	return len(sshClientPool.clients)
+}
+
+// waitForEmptyPool tolerates the asynchronous close of evicted entries
+func waitForEmptyPool(t *testing.T) {
+	t.Helper()
+	for range 100 {
+		if poolSize() == 0 {
+			return
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	t.Fatalf("pool still holds %d entries", poolSize())
+}
+
+// listenAndIgnore accepts connections but never speaks ssh, which is how a server under
+// load or a tarpitting firewall behaves. ssh.Dial would block on the handshake forever.
+func listenAndIgnore(t *testing.T) (string, int) {
+	t.Helper()
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	var mutex sync.Mutex
+	var conns []net.Conn
+	go func() {
+		for {
+			conn, err := listener.Accept()
+			if err != nil {
+				return
+			}
+			mutex.Lock()
+			conns = append(conns, conn)
+			mutex.Unlock()
+		}
+	}()
+	t.Cleanup(func() {
+		_ = listener.Close()
+		mutex.Lock()
+		defer mutex.Unlock()
+		for _, conn := range conns {
+			_ = conn.Close()
+		}
+	})
+	addr := listener.Addr().(*net.TCPAddr)
+	return addr.IP.String(), addr.Port
+}
+
+func TestHandshakeDoesNotHang(t *testing.T) {
+	original := sshTCPTimeoutSeconds
+	sshTCPTimeoutSeconds = 1
+	t.Cleanup(func() { sshTCPTimeoutSeconds = original })
+
+	host, port := listenAndIgnore(t)
+	start := time.Now()
+	if _, err := getSSHClientWithOptions(host, port, "root", testPrivateKey(t), false); err == nil {
+		t.Fatal("expected an error from a server that never completes the handshake")
+	}
+	if elapsed := time.Since(start); elapsed > 5*time.Second {
+		t.Fatalf("handshake took %s, it should be bounded by the tcp timeout", elapsed)
+	}
+	waitForEmptyPool(t)
+}
+
+// A stuck handshake used to hold a write lock that every other caller for the same host
+// blocked on, and a concurrent eviction could stall the whole pool behind it.
+func TestConcurrentCallersDoNotBlockOnStuckHandshake(t *testing.T) {
+	original := sshTCPTimeoutSeconds
+	sshTCPTimeoutSeconds = 1
+	t.Cleanup(func() { sshTCPTimeoutSeconds = original })
+
+	host, port := listenAndIgnore(t)
+	key := testPrivateKey(t)
+	done := make(chan struct{})
+	var wg sync.WaitGroup
+	for range 20 {
+		wg.Go(func() {
+			_, _ = getSSHClientWithOptions(host, port, "root", key, false)
+			DeleteSSHClient(host)
+		})
+	}
+	go func() {
+		wg.Wait()
+		close(done)
+	}()
+	select {
+	case <-done:
+	case <-time.After(30 * time.Second):
+		t.Fatal("concurrent callers deadlocked")
+	}
+	waitForEmptyPool(t)
+}
+
+// Rotating the key must not keep serving the connection opened with the old one.
+func TestRotatedCredentialsReplacePoolEntry(t *testing.T) {
+	host := "127.0.0.1"
+	entry, owned := acquireSSHClientEntry(host, 22, "root", credentialHash("old-key"))
+	if !owned {
+		t.Fatal("expected to own a freshly created entry")
+	}
+	close(entry.ready) // stand in for a completed handshake
+
+	same, owned := acquireSSHClientEntry(host, 22, "root", credentialHash("old-key"))
+	if owned || same != entry {
+		t.Fatal("unchanged credentials should reuse the pooled entry")
+	}
+
+	rotated, owned := acquireSSHClientEntry(host, 22, "root", credentialHash("new-key"))
+	if !owned || rotated == entry {
+		t.Fatal("rotated credentials should replace the pooled entry")
+	}
+	close(rotated.ready)
+	DeleteSSHClient(host)
+	waitForEmptyPool(t)
+}
+
+func TestDifferentPortReplacesPoolEntry(t *testing.T) {
+	host := "127.0.0.1"
+	first, _ := acquireSSHClientEntry(host, 22, "root", credentialHash("key"))
+	close(first.ready)
+	second, owned := acquireSSHClientEntry(host, 2222, "root", credentialHash("key"))
+	if !owned || second == first {
+		t.Fatal("a different port should not reuse the pooled entry")
+	}
+	close(second.ready)
+	DeleteSSHClient(host)
+	waitForEmptyPool(t)
+}
+
+func TestDeleteSSHClientKeepsNewerEntry(t *testing.T) {
+	host := "127.0.0.1"
+	stale, _ := acquireSSHClientEntry(host, 22, "root", credentialHash("key"))
+	close(stale.ready)
+	current, _ := acquireSSHClientEntry(host, 2222, "root", credentialHash("key"))
+	close(current.ready)
+
+	deleteSSHClientEntry(host, stale)
+	if poolSize() != 1 {
+		t.Fatal("deleting a stale entry should leave the newer one in place")
+	}
+	deleteSSHClientEntry(host, current)
+	waitForEmptyPool(t)
+}
+
+func TestCredentialHashDetectsChange(t *testing.T) {
+	if credentialHash("a") == credentialHash("b") {
+		t.Fatal("hash should differ per key")
+	}
+}

--- a/ssh_toolkit/timeout.go
+++ b/ssh_toolkit/timeout.go
@@ -1,6 +1,17 @@
 package ssh_toolkit
 
+import "time"
+
 var sshTCPTimeoutSeconds = 10
+
+var (
+	// keepalive probes, to detect a connection that died without the TCP stack noticing
+	sshKeepAliveInterval    = 15 * time.Second
+	sshKeepAliveTimeout     = 10 * time.Second
+	sshKeepAliveMaxFailures = 3
+	// upper bound on a single remote command, so a stuck one can never pin a goroutine forever
+	sshCommandMaxDuration = 30 * time.Minute
+)
 
 func UpdateTCPTimeout(t int) {
 	sshTCPTimeoutSeconds = t

--- a/ssh_toolkit/types.go
+++ b/ssh_toolkit/types.go
@@ -7,7 +7,7 @@ import (
 )
 
 type sshConnectionPool struct {
-	clients   map[string]*sshClient // map of <host:port> to sshClient
+	clients   map[string]*sshClient // map of host to sshClient
 	mutex     *sync.RWMutex
 	validator *ServerOnlineStatusValidator
 }
@@ -16,7 +16,16 @@ type ServerOnlineStatusValidator func(host string) bool
 
 type sshClient struct {
 	client *ssh.Client
-	mutex  *sync.RWMutex
+	err    error
+	// ready is closed once client and err are populated
+	ready chan struct{}
+	// credentials this connection was established with, to detect rotation
+	port     int
+	user     string
+	credHash string
+
+	stopKeepAlive chan struct{}
+	closeOnce     sync.Once
 }
 
 type OperatingSystem string

--- a/swiftwave_service/cronjob/server_status_monitor.go
+++ b/swiftwave_service/cronjob/server_status_monitor.go
@@ -11,6 +11,9 @@ import (
 	"github.com/swiftwave-org/swiftwave/swiftwave_service/logger"
 )
 
+// guards against stacking up checks for a server that is responding slowly
+var serverStatusCheckInFlight sync.Map
+
 func (m Manager) MonitorServerStatus() {
 	logger.CronJobLogger.Println("Starting server status monitor [cronjob]")
 	for {
@@ -38,9 +41,13 @@ func (m Manager) monitorServerStatus() {
 		if server.Status == core.ServerNeedsSetup || server.Status == core.ServerPreparing {
 			continue
 		}
+		if _, busy := serverStatusCheckInFlight.LoadOrStore(server.IP, struct{}{}); busy {
+			continue
+		}
 		wg.Add(1)
 		go func(server core.Server) {
 			defer wg.Done()
+			defer serverStatusCheckInFlight.Delete(server.IP)
 			m.checkAndUpdateServerStatus(server)
 		}(server)
 	}


### PR DESCRIPTION
Fixes #1389

## Problem

A pooled SSH client whose connection died silently — an idle flow dropped by a firewall/NAT, or a network partition — was never detected. `getSSHClientWithOptions` treated any non-`nil` client as healthy, so every caller got the dead client back and blocked in `session.Run` until the kernel gave up on the TCP connection (Linux default ~2h11m).

This matches the report in #1389 exactly: the instance shows **no SSH activity at all in sshd logs** while the status monitor claims to run every 2 seconds. No new connection is ever dialled because the pool keeps handing out the dead one. The server stays `offline` forever, and everything else then fails with `no online swarm manager`.

Secondary faults that made one bad host escalate:

- **`ssh.Dial` applies `config.Timeout` only to the TCP dial.** `NewClientConn` → `clientHandshake` runs with no deadline (`x/crypto@v0.50.0/ssh/client.go:177-187`), so a server that accepts TCP but never completes the handshake blocks forever. Verified with a standalone tarpit listener: `ssh.Dial` was still blocked after 5s with `Timeout: 1s`.
- That handshake ran while holding the per-entry write lock, so **every other caller for the same host** blocked on `clientEntry.mutex.RLock()` indefinitely.
- `DeleteSSHClient` waited on the entry lock **while holding the pool-wide write lock**, so a single stuck host stalled SSH for **every** host.
- `session.Run` had no upper bound at all — `sessionTimeoutSeconds` only bounded `client.NewSession()`, despite reading like a command timeout.

## Changes

- **Keepalive.** Each pooled client sends `keepalive@openssh.com` every 15s and is dropped after 3 consecutive failures. This is the core fix: closing the client also unblocks anything already stuck on it.
- **Bounded handshake.** Replaced `ssh.Dial` with `net.DialTimeout` + `conn.SetDeadline` + `ssh.NewClientConn`, clearing the deadline once the handshake completes.
- **Lock discipline.** The handshake now happens off the pool lock behind a `ready` channel, so waiters time out instead of blocking on a mutex. Evictions delete under the pool lock and close asynchronously — never wait on an entry while holding the pool lock. `deleteSSHClientEntry` compares identity so it can't evict a newer connection for the same host.
- **Credential rotation.** Pooled entries now carry the port, user and a hash of the private key; a change replaces the entry instead of reusing the connection opened with the old credentials.
- **Command bound.** `session.Run` replaced with `Start`/`Wait` under a 30-minute safety net. Deliberately generous — several callers run dependency installs with a 5s *session* timeout, so reusing that value would break them. Connection liveness is the keepalive's job.
- **Leak fixes.** Sessions and connections that arrive after their timeout fired are now closed, as is the client orphaned when an entry is replaced mid-handshake. These previously accumulated against sshd's `MaxStartups`/`MaxSessions`, which makes *new* connections hang too.
- **`errors.go`.** The bare `"eof"` substring matched any stderr containing those three letters and evicted healthy clients. Replaced with `errors.Is(err, io.EOF)` + `"unexpected eof"`, and dropped a duplicated `"handshake failed"` entry.
- **Status monitor.** Skips a server whose previous check is still in flight, so slow hosts can't stack up goroutines.

## Testing

`go test -race ./ssh_toolkit/` — six new tests, all passing, no races. `TestHandshakeDoesNotHang` and `TestConcurrentCallersDoNotBlockOnStuckHandshake` run against a listener that accepts TCP and never speaks SSH; both hung indefinitely before this change.

Note: the pre-existing `swiftwave_service/dashboard` embed error (`pattern all:www`) is unrelated and also present on `develop` without a built frontend.

🤖 Generated with [Claude Code](https://claude.com/claude-code)