### PR TITLE
fix: validate domain names before they reach haproxy configuration

### DIFF
--- a/haproxy_manager/backend_switch.go
+++ b/haproxy_manager/backend_switch.go
@@ -10,6 +10,11 @@ import (
 )
 
 func (s Manager) AddBackendSwitch(transactionId string, listenerMode ListenerMode, bindPort int, backendName string, domainName string) error {
+	if listenerMode != TCPMode {
+		if err := ValidateDomainName(domainName); err != nil {
+			return err
+		}
+	}
 	// check if backend switch already exists
 	index, err := s.FetchBackendSwitchIndex(transactionId, listenerMode, bindPort, backendName, domainName)
 	if err != nil {
@@ -60,6 +65,11 @@ func (s Manager) AddBackendSwitch(transactionId string, listenerMode ListenerMod
 }
 
 func (s Manager) FetchBackendSwitchIndex(transactionId string, listenerMode ListenerMode, bindPort int, backendName string, domainName string) (int, error) {
+	if listenerMode != TCPMode {
+		if err := ValidateDomainName(domainName); err != nil {
+			return -1, err
+		}
+	}
 	frontendName := s.GenerateFrontendName(listenerMode, bindPort)
 	params := QueryParameters{}
 	params.add("transaction_id", transactionId)

--- a/haproxy_manager/basic_auth.go
+++ b/haproxy_manager/basic_auth.go
@@ -194,6 +194,9 @@ func (s Manager) SetupBasicAuthentication(transactionId string, listenerMode Lis
 	if listenerMode == TCPMode {
 		return errors.New("basic authentication is not supported for TCP mode")
 	}
+	if err := ValidateDomainName(domain); err != nil {
+		return err
+	}
 	frontendName := s.GenerateFrontendName(listenerMode, bindPort)
 	// check if user-list exists
 	isUserListExist, err := s.IsUserListExist(transactionId, userListName)

--- a/haproxy_manager/domain_validation.go
+++ b/haproxy_manager/domain_validation.go
@@ -1,0 +1,45 @@
+package haproxymanager
+
+import (
+	"errors"
+	"strings"
+)
+
+var errInvalidDomainName = errors.New("invalid domain name")
+
+// ValidateDomainName accepts only an RFC 1123 hostname.
+//
+// Domain names end up inside haproxy ACL expressions and config file names, both of which
+// are built by string concatenation, so anything outside [a-zA-Z0-9-.] must be rejected
+// before it reaches the shared frontend configuration.
+func ValidateDomainName(domainName string) error {
+	domainName = strings.TrimSpace(domainName)
+	if domainName == "" || len(domainName) > 253 {
+		return errInvalidDomainName
+	}
+	for _, label := range strings.Split(domainName, ".") {
+		if !isValidDomainLabel(label) {
+			return errInvalidDomainName
+		}
+	}
+	return nil
+}
+
+func isValidDomainLabel(label string) bool {
+	if len(label) == 0 || len(label) > 63 {
+		return false
+	}
+	if label[0] == '-' || label[len(label)-1] == '-' {
+		return false
+	}
+	for _, char := range label {
+		isAllowed := (char >= 'a' && char <= 'z') ||
+			(char >= 'A' && char <= 'Z') ||
+			(char >= '0' && char <= '9') ||
+			char == '-'
+		if !isAllowed {
+			return false
+		}
+	}
+	return true
+}

--- a/haproxy_manager/domain_validation_test.go
+++ b/haproxy_manager/domain_validation_test.go
@@ -1,0 +1,60 @@
+package haproxymanager
+
+import "testing"
+
+func TestValidateDomainNameAcceptsRealHostnames(t *testing.T) {
+	valid := []string{
+		"example.com",
+		"sub.example.com",
+		"a.b.c.d.example.co.uk",
+		"my-app-1.example.com",
+		"localhost",
+		"123.example.com",
+	}
+	for _, domain := range valid {
+		if err := ValidateDomainName(domain); err != nil {
+			t.Errorf("%q should be accepted, got %v", domain, err)
+		}
+	}
+}
+
+func TestValidateDomainNameRejectsAclInjection(t *testing.T) {
+	invalid := []string{
+		"attacker.example } or { src 0.0.0.0/0 } #",
+		"example.com }",
+		"{ src 0.0.0.0/0 }",
+		"example.com or { src 0.0.0.0/0 }",
+		"example.com\n  acl anything",
+		"example.com/../../etc/haproxy",
+		"example.com:8080",
+		"",
+		"   ",
+		"..",
+		"example..com",
+		"-example.com",
+		"example-.com",
+	}
+	for _, domain := range invalid {
+		if err := ValidateDomainName(domain); err == nil {
+			t.Errorf("%q should be rejected", domain)
+		}
+	}
+}
+
+func TestValidateDomainNameRejectsOversizedInput(t *testing.T) {
+	label := make([]byte, 64)
+	for i := range label {
+		label[i] = 'a'
+	}
+	if err := ValidateDomainName(string(label) + ".com"); err == nil {
+		t.Error("a label longer than 63 characters should be rejected")
+	}
+
+	long := ""
+	for range 40 {
+		long += "abcdef."
+	}
+	if err := ValidateDomainName(long + "com"); err == nil {
+		t.Error("a name longer than 253 characters should be rejected")
+	}
+}

--- a/haproxy_manager/https_redirection.go
+++ b/haproxy_manager/https_redirection.go
@@ -11,6 +11,9 @@ import (
 )
 
 func (s Manager) EnableHTTPSRedirection(transactionId string, domainName string) error {
+	if err := ValidateDomainName(domainName); err != nil {
+		return err
+	}
 	frontendName := s.GenerateFrontendName(HTTPMode, 80)
 	// check if http-request rule already exists
 	index, err := s.FetchIndexOfHTTPSRedirection(transactionId, domainName)
@@ -49,6 +52,9 @@ func (s Manager) EnableHTTPSRedirection(transactionId string, domainName string)
 }
 
 func (s Manager) FetchIndexOfHTTPSRedirection(transactionId string, domainName string) (int, error) {
+	if err := ValidateDomainName(domainName); err != nil {
+		return -1, err
+	}
 	frontendName := s.GenerateFrontendName(HTTPMode, 80)
 
 	params := QueryParameters{}

--- a/haproxy_manager/ssl.go
+++ b/haproxy_manager/ssl.go
@@ -10,6 +10,10 @@ import (
 // UpdateSSL : Add SSL certificate to HAProxy
 func (s Manager) UpdateSSL(transactionId string, domain string, privateKey []byte, fullChain []byte) error {
 	_ = transactionId
+	// the domain becomes the certificate file name
+	if err := ValidateDomainName(domain); err != nil {
+		return err
+	}
 	// Create a new buffer
 	var buffer bytes.Buffer
 	// Add the full chain

--- a/swiftwave_service/core/domain.operations.go
+++ b/swiftwave_service/core/domain.operations.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 	"time"
 
+	haproxymanager "github.com/swiftwave-org/swiftwave/haproxy_manager"
 	"gorm.io/gorm"
 )
 
@@ -35,6 +36,9 @@ func (domain *Domain) FindById(_ context.Context, db gorm.DB, id uint) error {
 }
 
 func (domain *Domain) Create(_ context.Context, db gorm.DB) error {
+	if err := haproxymanager.ValidateDomainName(domain.Name); err != nil {
+		return err
+	}
 	err := domain.validateAndFillSSLInfo()
 	if err != nil {
 		return err
@@ -44,6 +48,9 @@ func (domain *Domain) Create(_ context.Context, db gorm.DB) error {
 }
 
 func (domain *Domain) Update(_ context.Context, db gorm.DB) error {
+	if err := haproxymanager.ValidateDomainName(domain.Name); err != nil {
+		return err
+	}
 	err := domain.validateAndFillSSLInfo()
 	if err != nil {
 		return err


### PR DESCRIPTION
## Problem

Domain names are concatenated into haproxy configuration without any format check. There is no hostname validation anywhere in the codebase — `Domain.Create()` / `Domain.Update()` only call `validateAndFillSSLInfo()`, which validates the TLS certificate and key, never the name itself.

The value flows into:

- backend switching rule conditions — `haproxy_manager/backend_switch.go:32`, `:34`, `:82`, `:84`
- https redirection rule conditions — `haproxy_manager/https_redirection.go:36`, `:73`
- the basic auth condition — `haproxy_manager/basic_auth.go:186`
- the certificate file name — `haproxy_manager/ssl.go:26`

Since these are built by string concatenation and pushed to the shared load balancer, a name that is not a well-formed hostname is carried through verbatim.

## Changes

- New `ValidateDomainName` in `haproxy_manager/domain_validation.go`: strict RFC 1123 — labels of `[a-zA-Z0-9-]`, 1–63 characters each, no leading or trailing hyphen, 253 characters total. There is no wildcard-domain support in the codebase, so no exception is needed for one.
- Applied at the entry point (`Domain.Create` / `Domain.Update`) **and** at the `haproxy_manager` boundary. The manager functions are exported and callable independently of the resolvers, so validating only at the entry point would leave them unguarded.
- Skipped for TCP-mode backend switches, which build no host condition.
- Not applied in `RemoveBasicAuthentication`, so any pre-existing rule can still be cleaned up — the value is only compared there, never written.

## Testing

`go test ./haproxy_manager/ -run TestValidateDomainName` — 3 new tests covering accepted hostnames, rejected malformed input, and length limits.

Note: the pre-existing haproxy integration tests fail in my environment on `dial unix .../dataplaneapi.sock: permission denied` (they need root for the docker volume). Identical failure on `develop` without these changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)