### PR TITLE
fix: throttle failed login attempts

### DIFF
--- a/swiftwave_service/rest/auth.go
+++ b/swiftwave_service/rest/auth.go
@@ -1,6 +1,8 @@
 package rest
 
 import (
+	"math"
+	"strconv"
 	"strings"
 	"time"
 
@@ -9,6 +11,9 @@ import (
 	"github.com/xlzd/gotp"
 )
 
+// there is one http server per process, so the throttle is shared by every login handler
+var loginAttempts = newLoginThrottle()
+
 // POST /auth/login
 func (server *Server) login(c echo.Context) error {
 	// Get params
@@ -16,38 +21,49 @@ func (server *Server) login(c echo.Context) error {
 	password := c.FormValue("password")
 	totp := c.FormValue("totp")
 
+	// Throttle keys, scoped per account and per source so neither one alone lets an
+	// attacker keep guessing
+	userKey := "user:" + strings.ToLower(strings.TrimSpace(username))
+	ipKey := "ip:" + c.RealIP()
+	totpUserKey := "totp:" + userKey
+	totpIPKey := "totp:" + ipKey
+
+	if wait := loginAttempts.lockedFor(userKey, ipKey, totpUserKey, totpIPKey); wait > 0 {
+		return tooManyAttempts(c, wait)
+	}
+
 	// Check if user exists
 	user, err := core.FindUserByUsername(c.Request().Context(), server.ServiceManager.DbClient, username)
 	if err != nil {
-		return c.JSON(400, &LoginResponse{
-			Message:      "user does not exist",
-			Token:        "",
-			TotpRequired: false,
-		})
-	}
-
-	// check if totp is enabled
-	if user.TotpEnabled && strings.Compare(totp, "") == 0 {
-		return c.JSON(400, &LoginResponse{
-			Message:      "two factor authentication is enabled, but totp is not provided",
-			Token:        "",
-			TotpRequired: true,
-		})
+		loginAttempts.fail(userKey, loginFailureThreshold, loginBaseLockout, loginMaxLockout)
+		loginAttempts.fail(ipKey, loginFailureThreshold, loginBaseLockout, loginMaxLockout)
+		return invalidCredentials(c)
 	}
 
 	// Check password
 	if !user.CheckPassword(password) {
-		return c.JSON(400, &LoginResponse{
-			Message:      "invalid password",
-			Token:        "",
-			TotpRequired: false,
-		})
+		loginAttempts.fail(userKey, loginFailureThreshold, loginBaseLockout, loginMaxLockout)
+		loginAttempts.fail(ipKey, loginFailureThreshold, loginBaseLockout, loginMaxLockout)
+		return invalidCredentials(c)
 	}
 
 	// Check totp
+	// asked for only after the password is verified, so an unauthenticated caller cannot
+	// discover which usernames exist or which of them have two factor enabled
 	if user.TotpEnabled {
+		if strings.Compare(totp, "") == 0 {
+			return c.JSON(400, &LoginResponse{
+				Message:      "two factor authentication is enabled, but totp is not provided",
+				Token:        "",
+				TotpRequired: true,
+			})
+		}
 		totpRecord := gotp.NewDefaultTOTP(user.TotpSecret)
 		if !totpRecord.Verify(totp, time.Now().Unix()) {
+			// a six digit code is small enough to exhaust within one validity window,
+			// so failures here are budgeted far more tightly than password failures
+			loginAttempts.fail(totpUserKey, totpFailureThreshold, totpBaseLockout, totpMaxLockout)
+			loginAttempts.fail(totpIPKey, totpFailureThreshold, totpBaseLockout, totpMaxLockout)
 			return c.JSON(400, &LoginResponse{
 				Message:      "invalid totp",
 				Token:        "",
@@ -66,10 +82,33 @@ func (server *Server) login(c echo.Context) error {
 		})
 	}
 
+	loginAttempts.clear(userKey, ipKey, totpUserKey, totpIPKey)
+
 	// Return token
 	return c.JSON(200, &LoginResponse{
 		Message:      "success",
 		Token:        token,
+		TotpRequired: false,
+	})
+}
+
+// private functions
+// invalidCredentials keeps the response identical for an unknown user and a wrong
+// password, so the endpoint cannot be used to enumerate usernames
+func invalidCredentials(c echo.Context) error {
+	return c.JSON(400, &LoginResponse{
+		Message:      "invalid credentials",
+		Token:        "",
+		TotpRequired: false,
+	})
+}
+
+func tooManyAttempts(c echo.Context, wait time.Duration) error {
+	seconds := int(math.Ceil(wait.Seconds()))
+	c.Response().Header().Set("Retry-After", strconv.Itoa(seconds))
+	return c.JSON(429, &LoginResponse{
+		Message:      "too many failed login attempts, try again in " + strconv.Itoa(seconds) + " seconds",
+		Token:        "",
 		TotpRequired: false,
 	})
 }

--- a/swiftwave_service/rest/login_throttle.go
+++ b/swiftwave_service/rest/login_throttle.go
@@ -1,0 +1,104 @@
+package rest
+
+import (
+	"sync"
+	"time"
+)
+
+const (
+	// password attempts, counted per username and per source ip
+	loginFailureThreshold = 5
+	loginBaseLockout      = 30 * time.Second
+	loginMaxLockout       = 15 * time.Minute
+	// a totp code is only six digits, so it gets a far smaller budget than a password
+	totpFailureThreshold = 3
+	totpBaseLockout      = 5 * time.Minute
+	totpMaxLockout       = 1 * time.Hour
+	// a key with no recent failure is forgotten
+	loginRecordTTL = 1 * time.Hour
+)
+
+type loginThrottle struct {
+	mutex     sync.Mutex
+	records   map[string]*loginAttemptRecord
+	lastSweep time.Time
+}
+
+type loginAttemptRecord struct {
+	failures    int
+	lockedUntil time.Time
+	lastFailure time.Time
+}
+
+func newLoginThrottle() *loginThrottle {
+	return &loginThrottle{records: make(map[string]*loginAttemptRecord)}
+}
+
+// lockedFor reports how long the caller must wait before another attempt is accepted,
+// zero when none of the keys is locked.
+func (t *loginThrottle) lockedFor(keys ...string) time.Duration {
+	now := time.Now()
+	t.mutex.Lock()
+	defer t.mutex.Unlock()
+	var longest time.Duration
+	for _, key := range keys {
+		record, ok := t.records[key]
+		if !ok {
+			continue
+		}
+		if remaining := record.lockedUntil.Sub(now); remaining > longest {
+			longest = remaining
+		}
+	}
+	return longest
+}
+
+// fail counts a failed attempt against key and locks it once the threshold is crossed,
+// backing off exponentially with every further failure.
+func (t *loginThrottle) fail(key string, threshold int, base, max time.Duration) {
+	now := time.Now()
+	t.mutex.Lock()
+	defer t.mutex.Unlock()
+	t.sweep(now)
+	record, ok := t.records[key]
+	if !ok {
+		record = &loginAttemptRecord{}
+		t.records[key] = record
+	}
+	record.failures++
+	record.lastFailure = now
+	if record.failures < threshold {
+		return
+	}
+	lockout := base
+	for range record.failures - threshold {
+		lockout *= 2
+		if lockout >= max {
+			lockout = max
+			break
+		}
+	}
+	record.lockedUntil = now.Add(lockout)
+}
+
+// clear forgets the failures recorded against keys, called once an attempt succeeds.
+func (t *loginThrottle) clear(keys ...string) {
+	t.mutex.Lock()
+	defer t.mutex.Unlock()
+	for _, key := range keys {
+		delete(t.records, key)
+	}
+}
+
+// sweep drops records that are both unlocked and idle, callers must hold the mutex.
+func (t *loginThrottle) sweep(now time.Time) {
+	if now.Sub(t.lastSweep) < loginRecordTTL {
+		return
+	}
+	t.lastSweep = now
+	for key, record := range t.records {
+		if now.After(record.lockedUntil) && now.Sub(record.lastFailure) > loginRecordTTL {
+			delete(t.records, key)
+		}
+	}
+}

--- a/swiftwave_service/rest/login_throttle_test.go
+++ b/swiftwave_service/rest/login_throttle_test.go
@@ -1,0 +1,121 @@
+package rest
+
+import (
+	"testing"
+	"time"
+)
+
+func TestThrottleAllowsAttemptsBelowThreshold(t *testing.T) {
+	throttle := newLoginThrottle()
+	for range loginFailureThreshold - 1 {
+		throttle.fail("user:alice", loginFailureThreshold, loginBaseLockout, loginMaxLockout)
+	}
+	if wait := throttle.lockedFor("user:alice"); wait > 0 {
+		t.Fatalf("should not be locked before the threshold, got %s", wait)
+	}
+}
+
+func TestThrottleLocksAtThreshold(t *testing.T) {
+	throttle := newLoginThrottle()
+	for range loginFailureThreshold {
+		throttle.fail("user:alice", loginFailureThreshold, loginBaseLockout, loginMaxLockout)
+	}
+	wait := throttle.lockedFor("user:alice")
+	if wait <= 0 {
+		t.Fatal("should be locked once the threshold is reached")
+	}
+	if wait > loginBaseLockout {
+		t.Fatalf("first lockout should be the base duration, got %s", wait)
+	}
+}
+
+func TestThrottleBacksOffExponentiallyUpToCap(t *testing.T) {
+	throttle := newLoginThrottle()
+	for range loginFailureThreshold {
+		throttle.fail("user:alice", loginFailureThreshold, loginBaseLockout, loginMaxLockout)
+	}
+	previous := throttle.lockedFor("user:alice")
+	for range 3 {
+		throttle.fail("user:alice", loginFailureThreshold, loginBaseLockout, loginMaxLockout)
+		current := throttle.lockedFor("user:alice")
+		if current <= previous {
+			t.Fatalf("lockout should grow with each failure, %s did not exceed %s", current, previous)
+		}
+		previous = current
+	}
+	for range 20 {
+		throttle.fail("user:alice", loginFailureThreshold, loginBaseLockout, loginMaxLockout)
+	}
+	if wait := throttle.lockedFor("user:alice"); wait > loginMaxLockout {
+		t.Fatalf("lockout %s exceeded the cap of %s", wait, loginMaxLockout)
+	}
+}
+
+// A six digit code has a million possibilities, the point of the tighter budget is that
+// an attacker cannot get anywhere near that many tries inside one validity window.
+func TestTotpBudgetIsTighterThanPassword(t *testing.T) {
+	if totpFailureThreshold >= loginFailureThreshold {
+		t.Fatal("totp should allow fewer attempts than a password")
+	}
+	throttle := newLoginThrottle()
+	for range totpFailureThreshold {
+		throttle.fail("totp:user:alice", totpFailureThreshold, totpBaseLockout, totpMaxLockout)
+	}
+	wait := throttle.lockedFor("totp:user:alice")
+	if wait < 30*time.Second {
+		t.Fatalf("totp lockout %s is too short to blunt a brute force", wait)
+	}
+}
+
+func TestThrottleIsPerKey(t *testing.T) {
+	throttle := newLoginThrottle()
+	for range loginFailureThreshold {
+		throttle.fail("user:alice", loginFailureThreshold, loginBaseLockout, loginMaxLockout)
+	}
+	if wait := throttle.lockedFor("user:bob"); wait > 0 {
+		t.Fatal("locking one account must not lock another")
+	}
+}
+
+func TestLockedForReportsLongestLock(t *testing.T) {
+	throttle := newLoginThrottle()
+	for range loginFailureThreshold {
+		throttle.fail("ip:10.0.0.1", loginFailureThreshold, loginBaseLockout, loginMaxLockout)
+	}
+	for range totpFailureThreshold + 4 {
+		throttle.fail("totp:ip:10.0.0.1", totpFailureThreshold, totpBaseLockout, totpMaxLockout)
+	}
+	combined := throttle.lockedFor("ip:10.0.0.1", "totp:ip:10.0.0.1")
+	if combined < throttle.lockedFor("totp:ip:10.0.0.1") {
+		t.Fatal("a locked key must not be masked by a less locked one")
+	}
+}
+
+func TestSuccessClearsFailures(t *testing.T) {
+	throttle := newLoginThrottle()
+	for range loginFailureThreshold {
+		throttle.fail("user:alice", loginFailureThreshold, loginBaseLockout, loginMaxLockout)
+	}
+	throttle.clear("user:alice")
+	if wait := throttle.lockedFor("user:alice"); wait > 0 {
+		t.Fatalf("a successful login should reset the counter, still locked for %s", wait)
+	}
+}
+
+func TestThrottleIsSafeUnderConcurrency(t *testing.T) {
+	throttle := newLoginThrottle()
+	done := make(chan struct{})
+	for i := range 50 {
+		go func() {
+			defer func() { done <- struct{}{} }()
+			throttle.fail("user:alice", loginFailureThreshold, loginBaseLockout, loginMaxLockout)
+			throttle.lockedFor("user:alice", "ip:10.0.0.1")
+			if i%10 == 0 {
+				throttle.clear("ip:10.0.0.1")
+			}
+		}()
+	}
+	for range 50 {
+		<-done
+	}
+}


### PR DESCRIPTION
Stacked on #1397 — review that one first. Base retargets to `develop` once #1397 merges.

## Problem

`POST /auth/login` (`swiftwave_service/rest/auth.go`) checks the password and, when enabled, the TOTP code, with no attempt counting, delay, or lockout. The echo middleware chain in `main.go` registers `RemoveTrailingSlash`, `RecoverWithConfig`, `LoggerWithConfig`, CORS and JWT auth — no rate limiter. Nothing else in the codebase implements one.

A six-digit TOTP code has only 10^6 possibilities and a ~30s validity window, so an unthrottled verification step meaningfully weakens the second factor for anyone who already holds the password.

The handler also revealed more than it should: it returned a distinct `user does not exist` message, and it answered `totp_required` **before** checking the password — telling an unauthenticated caller which usernames exist and which have 2FA enabled.

## Changes

`swiftwave_service/rest/login_throttle.go` (new) — an in-memory failed-attempt counter keyed independently by account and by source address, so neither dimension alone gives an attacker unlimited tries:

| | Threshold | Backoff | Cap |
|---|---|---|---|
| Password | 5 failures | 30s, doubling | 15 min |
| TOTP | 3 failures | 5 min, doubling | 1 hour |

- Locked requests get `429` with a `Retry-After` header.
- Counters clear on a successful login.
- Idle records are swept after an hour, so the map cannot grow without bound from random usernames or spoofed sources.

In the handler:
- Unknown user and wrong password now return an identical `invalid credentials` response.
- The TOTP prompt moved to **after** the password verifies. The dashboard flow is unaffected — it submits username+password first and prompts for the code on `totp_required`, which still happens, just only once the password is correct.

## Testing

`go test -race ./swiftwave_service/rest/` — 8 new tests: threshold boundary, exponential growth, cap enforcement, per-key isolation, longest-lock-wins across keys, reset on success, and concurrent access under the race detector.

## Not addressed

`FindUserByUsername` returns fast for an unknown user while a known user pays for a bcrypt comparison, so the endpoint remains distinguishable by timing. Worth a follow-up (compare against a dummy hash on the miss path); the throttle above bounds how much that can be sampled.

🤖 Generated with [Claude Code](https://claude.com/claude-code)