### PR TITLE
fix: sync proxy cronjob should use configured server user, not hardcoded root

### DIFF
--- a/swiftwave_service/cronjob/sync_proxy_state.go
+++ b/swiftwave_service/cronjob/sync_proxy_state.go
@@ -38,7 +38,7 @@ func (m Manager) syncProxy() {
 		return
 	}
 	// create conn over ssh
-	conn, err := ssh_toolkit.NetConnOverSSH("unix", swarmManager.DockerUnixSocketPath, 5, swarmManager.IP, swarmManager.SSHPort, "root", m.Config.SystemConfig.SshPrivateKey)
+	conn, err := ssh_toolkit.NetConnOverSSH("unix", swarmManager.DockerUnixSocketPath, 5, swarmManager.IP, swarmManager.SSHPort, swarmManager.User, m.Config.SystemConfig.SshPrivateKey)
 	if err != nil {
 		logger.CronJobLoggerError.Println("Failed to create conn over ssh", err.Error())
 		return


### PR DESCRIPTION
Fixes #1428

_Diagnosed and prepared with Claude (Anthropic) while debugging a related deploy issue (see #1427). Description below is accurate to my own review, not just generated text._

**The bug**

`syncProxy()` in `swiftwave_service/cronjob/sync_proxy_state.go` connects as `"root"` regardless of the server's configured `User` field:

```go
conn, err := ssh_toolkit.NetConnOverSSH("unix", swarmManager.DockerUnixSocketPath, 5, swarmManager.IP, swarmManager.SSHPort, "root", m.Config.SystemConfig.SshPrivateKey)
```

Every other caller of `NetConnOverSSH` (`manager/docker.go`, `manager/haproxy.go`, `manager/udpproxy.go`, `graphql/server.resolvers.go`) correctly passes `server.User` / `swarmManagerServer.User` instead. This one is the outlier.

**Impact**

On any server registered with a non-root management user where root SSH login is disabled (`PermitRootLogin no`), this cronjob — which runs every minute, indefinitely — fails every single time:

```
Failed to create conn over ssh ssh: handshake failed: ssh: unable to authenticate, attempted methods [none publickey], no supported methods remain
```

I confirmed on a live instance that this isn't a missing/misconfigured key — the swarm manager's own public key (derived from `system_configs.ssh_private_key`) is already correctly present in the configured user's `~/.ssh/authorized_keys`. The cronjob simply never tries that user.

**The fix**

One line — use `swarmManager.User` instead of the hardcoded `"root"`, matching every other call site.

**What I verified**

- `go build ./swiftwave_service/cronjob/...` and `go vet ./swiftwave_service/cronjob/...` both pass cleanly.
- `gofmt -l` reports no formatting issues.
- `swarmManager` is a `core.Server` (from `core.FetchSwarmManager`), the same type `docker.go`'s correct call site uses, so `.User` is a valid field access.

**What I have not verified**: a live end-to-end SSH connection through this exact code path with the fix applied — I don't have a disposable swarm-manager environment to safely re-exercise this cronjob against without affecting a real deployment. Flagging that plainly rather than claiming manual testing I didn't do.

#### Checks -
- [ ] Can be backported to older releases [If yes, please mention the release version]
- [ ] Tests Passed (Manual) — build/vet/gofmt verified, but live SSH re-test not performed; see caveat above
- [ ] Dashboard Updated (If necessary) — not needed, backend-only change
- [ ] Documentation Updated (If necessary) — not needed

Note: Please check **Allow edits from maintainers.** before creating the PR.